### PR TITLE
filter tables lazy loaded using dbplyr

### DIFF
--- a/R/selectInput_column.R
+++ b/R/selectInput_column.R
@@ -22,7 +22,7 @@ columnSelectInput <- function(inputId, label, data, choices = names,
   datar <- if (is.reactive(data)) data else reactive(data)
 
   if (is.function(choices)) choices <- choices(datar())
-  choices <- intersect(choices, names(datar()))
+  choices <- intersect(choices, colnames(datar()))
 
   labels <- Map(function(col) {
     json <- sprintf(strip_leading_ws('
@@ -33,7 +33,8 @@ columnSelectInput <- function(inputId, label, data, choices = names,
     }'),
     col,
     attr(datar()[[col]], "label") %||% "",
-    get_dataFilter_class(datar()[[col]]))
+    #get_dataFilter_class(datar()[[col]]))
+    get_dataFilter_class(datar() %>% select(all_of(col)) %>% collect() %>% .[[col]]))
   }, col = choices)
 
   names(choices) <- labels

--- a/R/shiny_data_filter.R
+++ b/R/shiny_data_filter.R
@@ -213,7 +213,7 @@ shiny_data_filter <- function(input, output, session, data,
   })
 
   observeEvent(input$add_filter_select, {
-    if (!input$add_filter_select %in% names(datar())) return()
+    if (!input$add_filter_select %in% colnames(datar())) return()
 
     filter_log("observing add filter button press", verbose = verbose)
     update_filter(fid <- next_filter_id(), column_name = input$add_filter_select)

--- a/R/shiny_data_filter_item.R
+++ b/R/shiny_data_filter_item.R
@@ -160,7 +160,7 @@ shiny_data_filter_item <- function(input, output, session, data,
     module_return$column_name
   })
 
-  output$nrow <- shiny::renderText(nrow(module_return$data()))
+  output$nrow <- shiny::renderText(module_return$data() %>% dplyr::tally() %>% pull(n))
 
   filter_na <- shiny::reactive({
     if (is.null(input$filter_na_btn)) FALSE
@@ -173,7 +173,8 @@ shiny_data_filter_item <- function(input, output, session, data,
 
   vec <- shiny::reactive({
     if (is.null(module_return$column_name)) NULL
-    else data()[[module_return$column_name]]
+    #else data()[[module_return$column_name]]
+    else {data() %>% select(all_of(module_return$column_name)) %>% collect() %>% .[[module_return$column_name]]}
   })
 
   shiny::observeEvent(input$column_select, {
@@ -218,11 +219,12 @@ shiny_data_filter_item <- function(input, output, session, data,
     filter_log("providing data filtered by '",
       module_return$column_name, "'", verbose = verbose)
 
-    out_data <- if (!nrow(data())) data()
+    out_data <- if (FALSE) {data()}  #(!nrow(data())) data()
     else {
-      out_data <- subset(data(), vector_module_return()$mask())
-      for (col in intersect(names(data()), names(out_data)))
-        attributes(out_data[[col]]) <- attributes(data()[[col]])
+      out_data <- filter(data(), vector_module_return()$mask())
+      # out_data <- subset(data(), vector_module_return()$mask())
+      # for (col in intersect(names(data()), names(out_data)))
+      #   attributes(out_data[[col]]) <- attributes(data()[[col]])
       out_data
     }
 

--- a/R/shiny_vector_filter_character.R
+++ b/R/shiny_vector_filter_character.R
@@ -10,36 +10,42 @@ shiny_vector_filter_ui.character <- function(data, inputId) {
 #' @importFrom shiny reactive reactiveValues renderUI textInput isolate
 #' @export
 shiny_vector_filter.character <- function(data, inputId, ...) {
-  function(input, output, session, x = shiny::reactive(character()),
-      filter_na = shiny::reactive(FALSE), verbose = FALSE) {
+  if (length(unique(as.character(data))) > 5)
+    shiny_vector_filter_factor_many
+  else
+    shiny_vector_filter_factor_few
 
-    ns <- session$ns
-
-    module_return <- shiny::reactiveValues(code = TRUE, mask = TRUE)
-
-    output$ui <- shiny::renderUI({
-      filter_log("updating ui", verbose = verbose)
-      shiny::textInput(
-        ns("param"),
-        NULL,
-        value = shiny::isolate(input$param),
-        width = "100%"
-      )
-    })
-
-    module_return$code <- shiny::reactive({
-      if (is.null(input$param) || !nchar(input$param))
-        TRUE
-      else if (filter_na())
-        bquote(grepl(.(tolower(input$param)), tolower(.x), fixed = TRUE))
-      else
-        bquote(is.na(.x) | grepl(.(tolower(input$param)), tolower(.x), fixed = TRUE))
-    })
-
-    module_return$mask <- shiny::reactive({
-      eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
-    })
-
-    module_return
-  }
+  # function(input, output, session, x = shiny::reactive(character()),
+  #     filter_na = shiny::reactive(FALSE), verbose = FALSE) {
+  #
+  #   ns <- session$ns
+  #
+  #   module_return <- shiny::reactiveValues(code = TRUE, mask = TRUE)
+  #
+  #   output$ui <- shiny::renderUI({
+  #     filter_log("updating ui", verbose = verbose)
+  #     shiny::textInput(
+  #       ns("param"),
+  #       NULL,
+  #       value = shiny::isolate(input$param),
+  #       width = "100%"
+  #     )
+  #   })
+  #
+  #   module_return$code <- shiny::reactive({
+  #     if (is.null(input$param) || !nchar(input$param))
+  #       TRUE
+  #     else if (filter_na())
+  #       bquote(tolower(.x) %in% .(tolower(input$param)))
+  #     else
+  #       bquote(is.na(.x)|  tolower(.x) %in% .(tolower(input$param))) # | grepl(.(tolower(input$param)), tolower(.x), fixed = TRUE)
+  #   })
+  #
+  #   module_return$mask <- shiny::reactive({
+  #     #eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+  #     TRUE
+  #   })
+  #
+  #   module_return
+  # }
 }

--- a/R/shiny_vector_filter_factor_few.R
+++ b/R/shiny_vector_filter_factor_few.R
@@ -1,5 +1,5 @@
 #' A vector filter for factors with only a few choices
-#' 
+#'
 #' @param input requisite shiny module field specifying incoming ui input
 #'   reactiveValues
 #' @param output requisite shiny module field capturing output for the shiny
@@ -15,32 +15,32 @@
 #' @return a \code{\link[shiny]{reactiveValues}} list containing a logical
 #'   vector called "mask" which can be used to filter the provided vector and an
 #'   element "code" which is the expression used to generate the mask.
-#' 
+#'
 #' @importFrom shiny reactive reactiveValues renderUI div plotOutput
 #'   checkboxGroupInput renderPlot isolate
 #' @importFrom ggplot2 ggplot aes aes_ geom_bar coord_flip theme_void
 #'   scale_x_discrete scale_y_continuous
 #' @importFrom grDevices rgb
-shiny_vector_filter_factor_few <- function(input, output, session, 
-    x = shiny::reactive(factor()), filter_na = shiny::reactive(TRUE), 
+shiny_vector_filter_factor_few <- function(input, output, session,
+    x = shiny::reactive(factor()), filter_na = shiny::reactive(TRUE),
     verbose = FALSE) {
-  
+
   ns <- session$ns
-  
+
   x_wo_NA <- shiny::reactive(Filter(Negate(is.na), x()))
   module_return <- shiny::reactiveValues(code = TRUE, mask = TRUE)
-  
+
   choices <- shiny::reactive(unique(as.character(x_wo_NA())))
-  
+
   output$ui <- shiny::renderUI({
     filter_log("updating ui", verbose = verbose)
     shiny::div(style = "position: relative;",
       shiny::div(style = "
-        position: absolute; 
+        position: absolute;
         top: -2px; right: 16px; bottom: -2px; left: 16px;
-        animation: 
-          0.75s ease-out 0s 1 shinyDataFilterEnlargeX, 
-          0.5s ease-in  0s 1 shinyDataFilterFadeIn; 
+        animation:
+          0.75s ease-out 0s 1 shinyDataFilterEnlargeX,
+          0.5s ease-in  0s 1 shinyDataFilterFadeIn;
         transform-origin: left;",
         shiny::plotOutput(ns("plot"), height = "100%")),
       shiny::checkboxGroupInput(ns("param"), NULL,
@@ -65,24 +65,24 @@ shiny_vector_filter_factor_few <- function(input, output, session,
       ggplot2::theme_void() +
       ggplot2::scale_x_discrete(expand = c(0, 0)) +
       ggplot2::scale_y_continuous(expand = c(0, 0), limits = c(0, 1))
-    
+
     # Normalized
-    # ggplot2::ggplot() + 
+    # ggplot2::ggplot() +
     #   # sort factor so that it reflects checkbox order
     #   ggplot2::aes(x = factor(
-    #     as.character(x_wo_NA()), 
-    #     levels = rev(choices()))) + 
+    #     as.character(x_wo_NA()),
+    #     levels = rev(choices()))) +
     #   ggplot2::geom_bar(
     #     width = 0.95,
-    #     fill = grDevices::rgb(66/255, 139/255, 202/255), 
-    #     color = NA, 
+    #     fill = grDevices::rgb(66/255, 139/255, 202/255),
+    #     color = NA,
     #     alpha = 0.2) +
     #   ggplot2::coord_flip() +
-    #   ggplot2::theme_void() + 
+    #   ggplot2::theme_void() +
     #   ggplot2::scale_x_discrete(expand = c(0, 0)) +
     #   ggplot2::scale_y_continuous(expand = c(0, 0))
   })
-  
+
   module_return$code <- shiny::reactive({
     if (length(input$param))
       bquote(.x %in% .(c(if (filter_na()) c() else NA, input$param)))
@@ -91,10 +91,11 @@ shiny_vector_filter_factor_few <- function(input, output, session,
     else
       TRUE
   })
-  
+
   module_return$mask <- shiny::reactive({
-    eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+    #eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+    TRUE
   })
-  
+
   module_return
 }

--- a/R/shiny_vector_filter_factor_many.R
+++ b/R/shiny_vector_filter_factor_many.R
@@ -17,15 +17,15 @@
 #'   element "code" which is the expression used to generate the mask.
 #'
 #' @importFrom shiny reactive reactiveValues renderUI selectInput isolate
-shiny_vector_filter_factor_many <- function(input, output, session, 
-    x = shiny::reactive(factor()), filter_na = shiny::reactive(FALSE), 
+shiny_vector_filter_factor_many <- function(input, output, session,
+    x = shiny::reactive(factor()), filter_na = shiny::reactive(FALSE),
     verbose = FALSE) {
-  
+
   ns <- session$ns
 
   x_wo_NAs <- shiny::reactive(Filter(Negate(is.na), x()))
   module_return <- shiny::reactiveValues(code = TRUE, mask = TRUE)
-  
+
   output$ui <- shiny::renderUI({
     filter_log("updating ui", verbose = verbose)
     proportionSelectInput(ns("param"), NULL,
@@ -34,7 +34,7 @@ shiny_vector_filter_factor_many <- function(input, output, session,
       multiple = TRUE,
       width = "100%")
   })
-  
+
   module_return$code <- shiny::reactive({
     if (length(input$param))
       bquote(.x %in% .(c(if (filter_na()) c() else NA, input$param)))
@@ -43,10 +43,11 @@ shiny_vector_filter_factor_many <- function(input, output, session,
     else
       TRUE
   })
-  
+
   module_return$mask <- shiny::reactive({
-    eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+    #eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+    TRUE
   })
-  
+
   module_return
 }

--- a/R/shiny_vector_filter_logical.R
+++ b/R/shiny_vector_filter_logical.R
@@ -9,27 +9,27 @@ shiny_vector_filter_ui.logical <- function(data, inputId) {
 
 #' @export
 shiny_vector_filter.logical <- function(data, inputId, ...) {
-  function(input, output, session, 
-    x = shiny::reactive(logical()), filter_na = shiny::reactive(TRUE), 
+  function(input, output, session,
+    x = shiny::reactive(logical()), filter_na = shiny::reactive(TRUE),
     verbose = FALSE) {
-    
+
     ns <- session$ns
-    
+
     x_wo_NA <- shiny::reactive(Filter(Negate(is.na), x()))
     module_return <- shiny::reactiveValues(code = TRUE, mask = TRUE)
     choices <- shiny::reactive({
       Filter(function(i) i %in% x(), c("True" = TRUE, "False" = FALSE))
     })
-    
+
     output$ui <- shiny::renderUI({
       filter_log("updating ui", verbose = verbose)
       shiny::div(style = "position: relative;",
         shiny::div(style = "
-          position: absolute; 
+          position: absolute;
           top: -2px; right: 16px; bottom: -2px; left: 16px;
-          animation: 
-            0.75s ease-out 0s 1 shinyDataFilterEnlargeX, 
-            0.5s ease-in  0s 1 shinyDataFilterFadeIn; 
+          animation:
+            0.75s ease-out 0s 1 shinyDataFilterEnlargeX,
+            0.5s ease-in  0s 1 shinyDataFilterFadeIn;
           transform-origin: left;",
           shiny::plotOutput(ns("plot"), height = "100%")),
         shiny::checkboxGroupInput(ns("param"), NULL,
@@ -37,7 +37,7 @@ shiny_vector_filter.logical <- function(data, inputId, ...) {
           selected = shiny::isolate(input$param) %||% c(),
           width = "100%"))
     })
-  
+
     output$plot <- shiny::renderPlot(bg = 'transparent', {
       # Proportional
       ggplot2::ggplot() +
@@ -54,48 +54,49 @@ shiny_vector_filter.logical <- function(data, inputId, ...) {
         ggplot2::theme_void() +
         ggplot2::scale_x_discrete(expand = c(0, 0)) +
         ggplot2::scale_y_continuous(expand = c(0, 0), limits = c(0, 1))
-      
+
       # Normalized
-      # ggplot2::ggplot() + 
+      # ggplot2::ggplot() +
       #   # sort factor so that it reflects checkbox order
       #   ggplot2::aes(x = factor(
-      #     as.character(x_wo_NA()), 
-      #     levels = rev(choices()))) + 
+      #     as.character(x_wo_NA()),
+      #     levels = rev(choices()))) +
       #   ggplot2::geom_bar(
       #     width = 0.95,
-      #     fill = grDevices::rgb(66/255, 139/255, 202/255), 
-      #     color = NA, 
+      #     fill = grDevices::rgb(66/255, 139/255, 202/255),
+      #     color = NA,
       #     alpha = 0.2) +
       #   ggplot2::coord_flip() +
-      #   ggplot2::theme_void() + 
+      #   ggplot2::theme_void() +
       #   ggplot2::scale_x_discrete(expand = c(0, 0)) +
       #   ggplot2::scale_y_continuous(expand = c(0, 0))
     })
-    
+
     module_return$code <- shiny::reactive({
       exprs <- list()
-      
-      if (TRUE %in% input$param) 
+
+      if (TRUE %in% input$param)
         exprs <- append(exprs, list(quote(.x)))
-      if (FALSE %in% input$param) 
+      if (FALSE %in% input$param)
         exprs <- append(exprs, list(quote(!.x)))
-      
+
       if (length(input$param) == 2 && filter_na())
         exprs <- list(quote(!is.na(.x)))
-      else if (length(input$param) && !filter_na()) 
+      else if (length(input$param) && !filter_na())
         exprs <- append(exprs, list(quote(is.na(.x))))
-      
-      
-      if (length(exprs) && length(exprs) < 3) 
+
+
+      if (length(exprs) && length(exprs) < 3)
         Reduce(function(l, r) bquote(.(l) | .(r)), exprs)
-      else 
+      else
         TRUE
     })
-    
+
     module_return$mask <- shiny::reactive({
-      eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+      #eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+      TRUE
     })
-    
+
     module_return
   }
 }

--- a/R/shiny_vector_filter_numeric.R
+++ b/R/shiny_vector_filter_numeric.R
@@ -91,7 +91,8 @@ shiny_vector_filter.numeric <- function(data, inputId, ...) {
     })
 
     module_return$mask <- shiny::reactive({
-      eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+      #eval(do.call(substitute, list(module_return$code(), list(.x = x()))))
+      TRUE
     })
 
     module_return

--- a/inst/examples/basic_app/app.R
+++ b/inst/examples/basic_app/app.R
@@ -1,14 +1,14 @@
+library(dplyr)
+library(dbplyr)
+library(DBI)
 library(shiny)
-library(shinyDataFilter)
+devtools::load_all()
 
-library(dplyr)  # for data preprocessing and example data
-
-# prep a new data.frame with more diverse data types
 starwars2 <- starwars %>%
   mutate_if(~is.numeric(.) && all(Filter(Negate(is.na), .) %% 1 == 0), as.integer) %>%
   mutate_if(~is.character(.) && length(unique(.)) <= 25, as.factor) %>%
   mutate(is_droid = species == "Droid") %>%
-  select(name, gender, height, mass, hair_color, eye_color, vehicles, is_droid)
+  select(name, gender, height, mass, hair_color, eye_color, is_droid)
 
 # create some labels to showcase column select input
 attr(starwars2$name, "label")     <- "name of character"
@@ -17,34 +17,43 @@ attr(starwars2$height, "label")   <- "height of character in centimeters"
 attr(starwars2$mass, "label")     <- "mass of character in kilograms"
 attr(starwars2$is_droid, "label") <- "whether character is a droid"
 
+
+starwars2_sql <- tbl_memdb(starwars2)
+
 ui <- fluidPage(
   titlePanel("Filter Data Example"),
   fluidRow(
     column(8,
-      dataTableOutput("data_summary"),
-      verbatimTextOutput("data_filter_code")),
+           dataTableOutput("data_summary"),
+           verbatimTextOutput("data_filter_code")),
     column(4, shiny_data_filter_ui("data_filter"))))
 
 server <- function(input, output, session) {
   filtered_data <- callModule(
     shiny_data_filter,
     "data_filter",
-    data = starwars2,
-    choices = c("height", "mass", "is_droid"),
-    verbose = FALSE
+    data = starwars2_sql,
+    choices = c("height", "mass", "is_droid", "name", "hair_color", "gender"),
+    verbose = TRUE
   )
 
   output$data_filter_code <- renderPrint({
     cat(gsub("%>%", "%>% \n ",
-      gsub("\\s{2,}", " ",
-        paste0(
-          capture.output(attr(filtered_data(), "code")),
-          collapse = " "))
+             gsub("\\s{2,}", " ",
+                  paste0(
+                    capture.output(attr(filtered_data(), "code")),
+                    collapse = " "))
     ))
   })
 
   output$data_summary <- renderDataTable({
-    filtered_data()
+
+    eval(parse(text= gsub("\\s{2,}", " ",
+                               paste0(
+                                 capture.output(attr(filtered_data(), "code")),
+                                 collapse = " ")
+    ))) %>%
+      collect()
   },
   options = list(
     scrollX = TRUE,


### PR DESCRIPTION
this refers to this issue:

https://github.com/dgkf/shinyDataFilter/issues/26

This is a fantastic module, but my main shiny usage is with databases, so it wasnt compatible.
I created a pull request with code that "works".
However:

I had to give up on the "filtering at every step" as you add filters. instead the filtering only occurs at the end when displaying the resulting table.
character column are treated as factors (because there are no factors in databases)
The full vector is being downloaded from the database when creating the filters. It would be much better to download the counts of each possible values. (better to get the count of male and female instead of getting a 6-million long character vector).